### PR TITLE
Added signature secret JWT validation

### DIFF
--- a/src/JWT/TokenGenerator.php
+++ b/src/JWT/TokenGenerator.php
@@ -6,10 +6,15 @@ namespace Vonage\JWT;
 use Ramsey\Uuid\Uuid;
 use RuntimeException;
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Signer\Hmac\Sha256 as Sha256HMAC;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use stdClass;
+use Lcobucci\JWT\Token\Parser as TokenParser;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\Validator;
 use Vonage\JWT\Exception\InvalidJTIException;
 
 class TokenGenerator
@@ -260,5 +265,19 @@ class TokenGenerator
     public function getTTL() : int
     {
         return $this->ttl;
+    }
+
+    public static function verifySignature(string $token, string $secret): bool
+    {
+        $parser = new TokenParser(new JoseEncoder());
+        $validator = new Validator();
+
+        $token = $parser->parse($token);
+
+        return $validator->validate(
+            $token, new SignedWith(
+                new Sha256HMAC(),
+                InMemory::plainText($secret)
+            ));
     }
 }

--- a/test/JWT/TokenGeneratorTest.php
+++ b/test/JWT/TokenGeneratorTest.php
@@ -343,4 +343,18 @@ class TokenGeneratorTest extends TestCase
         $this->assertTrue($parsedToken->claims()->has('foo'));
         $this->assertSame('bar', $parsedToken->claims()->get('foo'));
     }
+
+    public function testCanValidateJWTWithSignatureSecret()
+    {
+        $token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1ODc0OTQ5NjIsImp0aSI6ImM1YmE4ZjI0LTFhMTQtNGMxMC1iZmRmLTNmYmU4Y2U1MTFiNSIsImlzcyI6IlZvbmFnZSIsInBheWxvYWRfaGFzaCI6ImQ2YzBlNzRiNTg1N2RmMjBlM2I3ZTUxYjMwYzBjMmE0MGVjNzNhNzc4NzliNmYwNzRkZGM3YTIzMTdkZDAzMWIiLCJhcGlfa2V5IjoiYTFiMmMzZCIsImFwcGxpY2F0aW9uX2lkIjoiYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtMDEyMzQ1Njc4OWFiIn0.JQRKi1d0SQitmjPINfTWMpt3XZkGsLbD7EjCdXoNSbk';
+        $secret = 'ZYtdTtGV3BCFN7tWmOWr1md66XsquMggr4W2cTtXtcPgfnI0Xw';
+        $this->assertTrue(TokenGenerator::verifySignature($token, $secret));
+    }
+
+    public function testWillNotValidateJWTWithBadSecret()
+    {
+        $token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1ODc0OTQ5NjIsImp0aSI6ImM1YmE4ZjI0LTFhMTQtNGMxMC1iZmRmLTNmYmU4Y2U1MTFiNSIsImlzcyI6IlZvbmFnZSIsInBheWxvYWRfaGFzaCI6ImQ2YzBlNzRiNTg1N2RmMjBlM2I3ZTUxYjMwYzBjMmE0MGVjNzNhNzc4NzliNmYwNzRkZGM3YTIzMTdkZDAzMWIiLCJhcGlfa2V5IjoiYTFiMmMzZCIsImFwcGxpY2F0aW9uX2lkIjoiYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtMDEyMzQ1Njc4OWFiIn0.JQRKi1d0SQitmjPINfTWMpt3XZkGsLbD7EjCdXoNSbk';
+        $secret = 'ZYtdTtGV3BCFN7tWmOWr1md66XsquMggr4W2cTtXtcPgf55555';
+        $this->assertFalse(TokenGenerator::verifySignature($token, $secret));
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds the `verifySignature()` method as proposed in [vonage/server-sdk-specification #5](https://raw.githubusercontent.com/Vonage/server-sdk-specification/rfc-5-jwt-update/rfcs/proposed/RFC-5-server-sdk-jwt-packages.md).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JWT-based callbacks in Messages and Voice (and eventually Video in the unified environment) will need to be verified differently than the legacy SMS system. This removes the boilerplate a user needs to do to verify the incoming JWT.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
