### PR TITLE
Allow more modern versions of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "library",
     "require": {
         "php": "~8.0 || ~8.1 || ~8.2",
-        "lcobucci/jwt": "^4.1.5",
-        "ramsey/uuid": "^3.9"
+        "lcobucci/jwt": "^4.1.5|^5.0",
+        "ramsey/uuid": "^3.9|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.4",

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "library",
     "require": {
         "php": "~8.0 || ~8.1 || ~8.2",
-        "lcobucci/jwt": "^4.1.5|^5.0",
-        "ramsey/uuid": "^3.9|^4.0"
+        "lcobucci/jwt": "^4.3.0|^5.0",
+        "ramsey/uuid": "^4.7.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.4",

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": "~8.0 || ~8.1 || ~8.2 || ~8.3",
         "lcobucci/jwt": "^4.7.5|^5.0",
+        "ramsey/uuid": "^4.7.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.4",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A standalone package for creating JWTs for Vonage APIs",
     "type": "library",
     "require": {
-        "php": "~8.0 || ~8.1 || ~8.2 || ~8.3",
+        "php": "~8.1 || ~8.2 || ~8.3",
         "lcobucci/jwt": "^4.7.5|^5.0",
         "ramsey/uuid": "^4.7.5"
     },

--- a/src/JWT/TokenGenerator.php
+++ b/src/JWT/TokenGenerator.php
@@ -138,30 +138,30 @@ class TokenGenerator
         $iat = time();
         $exp = $iat + $this->ttl;
 
-        $builder = $this->config->builder();
-        $builder->issuedAt((new \DateTimeImmutable())->setTimestamp($iat))
+        $builder = $this->config->builder()
+            ->issuedAt((new \DateTimeImmutable())->setTimestamp($iat))
             ->expiresAt((new \DateTimeImmutable())->setTimestamp($exp))
             ->identifiedBy($this->getJTI())
             ->withClaim('application_id', $this->applicationId);
 
         if (!empty($this->getPaths())) {
-            $builder->withClaim('acl', ['paths' => $this->getPaths()]);
+            $builder = $builder->withClaim('acl', ['paths' => $this->getPaths()]);
         }
 
         try {
-            $builder->canOnlyBeUsedAfter($this->getNotBefore());
+            $builder = $builder->canOnlyBeUsedAfter($this->getNotBefore());
         } catch (RuntimeException $e) {
             // This is fine, NBF isn't required
         }
 
         try {
-            $builder->relatedTo($this->getSubject());
+            $builder = $builder->relatedTo($this->getSubject());
         } catch (RuntimeException $e) {
             // This is fine, Subject isn't required
         }
 
         foreach ($this->claims as $key => $value) {
-            $builder->withClaim($key, $value);
+            $builder = $builder->withClaim($key, $value);
         }
 
         return $builder->getToken($this->config->signer(), $this->config->signingKey())->toString();


### PR DESCRIPTION
This PR allows us to install it with `lcobucci/jwt` v5 and `ramsey/uuid` v4.

## Description

It does what title says :)

## Motivation and Context

On our project we use the latest versions of `lcobucci/jwt` and `ramsey/uuid`, so we couldn't install the library without this fix.

## How Has This Been Tested?

I have performed `vendor/bin/phpunit` for both 4 and 5 versions of `lcobucci/jwt`. No errors have been reported.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
