### PR TITLE
bump up deps in preparation for major version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.0', '8.1', '8.2' ]
+        php: [ '8.0', '8.1', '8.2', '8.3' ]
     name: PHP ${{ matrix.php }} Test
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "A standalone package for creating JWTs for Vonage APIs",
     "type": "library",
     "require": {
-        "php": "~8.0 || ~8.1 || ~8.2",
-        "lcobucci/jwt": "^4.1.5",
-        "ramsey/uuid": "^3.9"
+        "php": "~8.0 || ~8.1 || ~8.2 || ~8.3",
+        "lcobucci/jwt": "^4.3.0",
+        "ramsey/uuid": "^4.7.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.4",


### PR DESCRIPTION
This PR bumps up dependencies, but will be shortly overridden by a new major version when PHP8.0 support drops.